### PR TITLE
Fix readthedocs build error with mock import

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -45,6 +45,7 @@ extensions = [
 ]
 
 autodoc_typehints = "description"
+autodoc_mock_imports = ["nupack"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
To try to fix the [build error with Read the Docs](https://readthedocs.org/projects/nuad/builds/17009358/), I tried to configure nupack as a [mock import](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_mock_imports) as suggested in [Read the Docs faq](https://docs.readthedocs.io/en/stable/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules). I can't think of a easy way to test this, so probably merging to dev and then to main to see if it works is easiest way to test. It's easy to undo this change if it doesn't work.