### PR TITLE
Install .par files when installing via pip.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include requirements.txt
 include LICENSE
+include nuad/nupack_viennaRNA_parameter_files/*.par

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,6 @@ setup(name='nuad',
       long_description=long_description,
       long_description_content_type='text/markdown; variant=GFM',
       python_requires='>=3.7',
-      install_requires=install_requires
+      install_requires=install_requires,
+      include_package_data=True
       )


### PR DESCRIPTION
When installed via pip, rather than by adding the nuad directory to Python's search path, the parameter files for ViennaRNA are not installed along with the package, causing ViennaRNA constraints to fail.

Making these changes to setup.py and MANIFEST.in should install the files correctly.
