### PR TITLE
Create directory before opening logs (fixes #182)

### DIFF
--- a/nuad/search.py
+++ b/nuad/search.py
@@ -1108,10 +1108,10 @@ def _setup_directories(params: SearchParameters) -> _Directories:
     out_directory = params.out_directory
     if out_directory is None:
         out_directory = default_output_directory()
+    if not os.path.exists(out_directory):
+        os.makedirs(out_directory)
     directories = _Directories(out=out_directory, debug=params.debug_log_file,
                                info=params.info_log_file)
-    if not os.path.exists(directories.out):
-        os.makedirs(directories.out)
     if not params.restart:
         _clear_directory(directories.out, params.force_overwrite)
     for subdir in directories.all_subdirectories(params):


### PR DESCRIPTION
This creates the output directory before initializing `_Directories`.

Leaving as a draft because it might be useful to make a test for this problem.