### PR TITLE
fix Domain.name docstring

### DIFF
--- a/nuad/constraints.py
+++ b/nuad/constraints.py
@@ -1633,7 +1633,7 @@ class Domain(Part, JSONSerializable):
     @property
     def name(self) -> str:
         """
-        :return: :any:`DomainPool` of this :any:`Domain`
+        :return: name of this :any:`Domain`
         """
         return self._name
 


### PR DESCRIPTION
In messing with writing a design script, I noticed that the `Domain.name` docstring wasn't right...