### PR TITLE
Update run_unit_tests.yml to install build-essential package

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -28,6 +28,8 @@ jobs:
           python -m pip install -U nupack -f /nupack/package
       - name: Install dependencies
         run: |
+          sudo apt update
+          sudo apt install -y build-essential
           if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
       - name: Test with unittest
         run: |


### PR DESCRIPTION
It appears that building the ViennaRNA package installation is failing due to missing build dependencies; namely, the `g++` compiler. I've added the installation step for it in this commit.